### PR TITLE
Allow creating a new tab or using the existing one when opening a session with a filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@
 
 Toggling the `ToggleWorkspace` command on will persistently track your session found in a current working directory, and all workspace features will be enabled. Conversely, toggling the command off will remove the session and disable the workspace features.
 
-If Vim is run with a file argument and it's already in the session's workspace, Vim will load the session and go to the tab window that contains it. Otherwise, it will be loaded as a new tab in the session.
+If Vim is run with a file argument and it's already in the session's workspace, Vim will load the session and go to the tab window that contains it. Otherwise, it will be loaded as a new tab in the session. If you would rather create a new buffer in the existing tab instead of creating a new tab:
+```
+let g:workspace_create_new_tabs = 0  " enabled = 1 (default), disabled = 0
+```
 
 It is recommended you bind this command to a convenient shortcut, such as the following:
 ```

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -14,6 +14,7 @@ let g:workspace_autosave_untrailspaces = get(g:, 'workspace_autosave_untrailspac
 let g:workspace_autosave_au_updatetime = get(g:, 'workspace_autosave_au_updatetime', 3)
 let g:workspace_autocreate = get(g:, 'workspace_autocreate', 0)
 let g:workspace_nocompatible = get(g:, 'workspace_nocompatible', 1)
+let g:workspace_create_new_tabs = get(g:, 'workspace_use_buffer', 1)
 
 function! s:WorkspaceExists()
   return filereadable(g:workspace_session_name)
@@ -36,16 +37,18 @@ endfunction
 
 function! s:FindOrNew(filename)
   let a:bufnr = bufnr(a:filename)
-  for tabnr in range(1, tabpagenr("$"))
-    for bufnr in tabpagebuflist(tabnr)
-      if (bufnr == a:bufnr)
-        execute 'tabn ' . tabnr
-        call win_gotoid(win_findbuf(a:bufnr)[0])
-        return
-      endif
+  if g:workspace_create_new_tabs
+    for tabnr in range(1, tabpagenr("$"))
+      for bufnr in tabpagebuflist(tabnr)
+        if (bufnr == a:bufnr)
+          execute 'tabn ' . tabnr
+          call win_gotoid(win_findbuf(a:bufnr)[0])
+          return
+        endif
+      endfor
     endfor
-  endfor
-  tabnew
+    tabnew
+  endif
   execute 'buffer ' . a:bufnr
 endfunction
 

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -16,7 +16,7 @@ let g:workspace_autosave_au_updatetime = get(g:, 'workspace_autosave_au_updateti
 let g:workspace_autocreate = get(g:, 'workspace_autocreate', 0)
 let g:workspace_nocompatible = get(g:, 'workspace_nocompatible', 1)
 let g:workspace_session_directory = get(g:, 'workspace_session_directory', '')
-let g:workspace_create_new_tabs = get(g:, 'workspace_create_new_tabs', 0)
+let g:workspace_create_new_tabs = get(g:, 'workspace_create_new_tabs', 1)
 
 function! s:IsSessionDirectoryUsed()
   return !empty(g:workspace_session_directory)


### PR DESCRIPTION
I use https://github.com/vim-airline/vim-airline, which has a "tabline" that shows all the buffers. When used in conjunction with `vim-workspace`, I thought it would be useful if opening a file via `vim file.txt` would create a new buffer in the existing tab, instead of creating a new tab.