### PR TITLE
Save workspace on ui leave - added support to headless nvim

### DIFF
--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -248,6 +248,7 @@ augroup Workspace
   au! VimEnter * nested call s:LoadWorkspace()
   au! StdinReadPost * let s:read_from_stdin = 1
   au! VimLeave * call s:MakeWorkspace(0)
+  au! UILeave * call s:MakeWorkspace(0)
   au! InsertLeave * if getcmdwintype() == '' && pumvisible() == 0|pclose|endif
   au! SessionLoadPost * call s:PostLoadCleanup()
 augroup END


### PR DESCRIPTION
Hi, I'm really enjoying your plugin! Great work

I noticed that it only saves the session on VimLeave, this was not working for me using [headless nvim in docker](github.com/GustavoKatel/devcontainers-rs/) because the process can be killed by the docker without triggering VimLeave autocommand.

To fix this I also made possible to save the session on UILeave:

```viml
au! UILeave * call s:MakeWorkspace(0)
```

It's been working fine so far and I wonder if you're interested in accepting this in upstream. Feel free to close this if it's out of scope or not interested.

Thanks!