### PR TITLE
Save workspace on ui leave - added support to headless nvim

### DIFF
--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -253,6 +253,9 @@ augroup Workspace
   else
     au! InsertLeave * if pumvisible() == 0|pclose|endif
   endif
+  if has('nvim')
+    au! UILeave * nested call s:MakeWorkspace(0)
+  endif
   au! SessionLoadPost * call s:PostLoadCleanup()
 augroup END
 


### PR DESCRIPTION
Hi, I'm really enjoying your plugin! Great work

I noticed that it only saves the session on VimLeave, this was not working for me using headless nvim in docker because the process can be killed by the docker without triggering VimLeave autocommand.

To fix this I also made possible to save the session on UILeave:

```viml
au! UILeave * call s:MakeWorkspace(0)
```

It's been working fine so far and I wonder if you're interested in accepting this in upstream. Feel free to close this if it's out of scope or not interested.

This supersedes #37 , I needed the master branch to test some new things, sorry the noise

Thanks!