### PR TITLE
Check if getcmdwintype exists before calling it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.swp
 Session.vim
 .undodir
+doc/tags
+

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -248,7 +248,11 @@ augroup Workspace
   au! VimEnter * nested call s:LoadWorkspace()
   au! StdinReadPost * let s:read_from_stdin = 1
   au! VimLeave * call s:MakeWorkspace(0)
-  au! InsertLeave * if getcmdwintype() == '' && pumvisible() == 0|pclose|endif
+  if exists('*getcmdwintype')
+    au! InsertLeave * if empty(getcmdwintype()) && pumvisible() == 0|pclose|endif
+  else
+    au! InsertLeave * if pumvisible() == 0|pclose|endif
+  endif
   au! SessionLoadPost * call s:PostLoadCleanup()
 augroup END
 


### PR DESCRIPTION
I have one machine with a bit older vim7.3 and that vim doesn't have `getcmdwintype` and spills many errors on each insert mode leave. So I added a small patch to check if the function exists, in a similar way like in [golden_ratio.vim](https://github.com/roman/golden-ratio/blob/master/plugin/golden_ratio.vim#L128).