### PR TITLE
Feature/set which files to autosave

### DIFF
--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -121,6 +121,10 @@ function! s:ToggleWorkspace()
 endfunction
 
 function! s:LoadWorkspace()
+  if len(g:workspace_autosave_files) > 0 && index(g:workspace_autosave_files, &filetype) == -1
+    return
+  endif
+
   if index(g:workspace_autosave_ignore, &filetype) != -1 || get(s:, 'read_from_stdin', 0) || (g:workspace_session_disable_on_args && argc() != 0)
     return
   endif

--- a/plugin/workspace.vim
+++ b/plugin/workspace.vim
@@ -17,6 +17,7 @@ let g:workspace_autocreate = get(g:, 'workspace_autocreate', 0)
 let g:workspace_nocompatible = get(g:, 'workspace_nocompatible', 1)
 let g:workspace_session_directory = get(g:, 'workspace_session_directory', '')
 let g:workspace_create_new_tabs = get(g:, 'workspace_create_new_tabs', 1)
+let g:workspace_autosave_files = get(g:, 'workspace_autosave_files', [])
 
 function! s:IsSessionDirectoryUsed()
   return !empty(g:workspace_session_directory)
@@ -160,6 +161,11 @@ function! s:UntrailTabs()
 endfunction
 
 function! s:Autosave(timed)
+  " If autosave files list is not empty and file is not in list, don't autosave
+  if len(g:workspace_autosave_files) > 0 && index(g:workspace_autosave_files, &filetype) == -1
+    return
+  endif
+
   if index(g:workspace_autosave_ignore, &filetype) != -1 || &readonly || mode() == 'c' || pumvisible()
     return
   endif


### PR DESCRIPTION
This plugin generate sooo many errors, trying to save workspace or file in invalid buffers, so I included a global variable to define what filetypes do you want to include for workspace/autosave.